### PR TITLE
Update QRCode when text attribute is changed

### DIFF
--- a/addon/components/qr-code.js
+++ b/addon/components/qr-code.js
@@ -39,5 +39,9 @@ export default Ember.Component.extend({
   willDestroyElement: function() {
     this.get('qrcode').clear();
   },
+
+  _recreateCode: Ember.observer('text', function() {
+    this.get('qrcode').makeCode(this.get('text'));
+  })
 });
 


### PR DESCRIPTION
This modification allows changes made to the text attribute to be reflected on the QRCode by calling the `makeCode` method with the new text.

I think this same approach can be used to update the QRCode when other attributes are changed as well, like width and height, but I have not tested that.